### PR TITLE
example: Add optional test for compatibility with Verilog Diagrams

### DIFF
--- a/example/source/conf.py
+++ b/example/source/conf.py
@@ -29,7 +29,8 @@ exclude_patterns = []
 # Optional extensions, used only for compatibility checks
 _optional_extensions = [
     # (extension_name, extension_test_document)
-    ("symbolator_sphinx", "symbolator.rst")
+    ("symbolator_sphinx", "symbolator.rst"),
+    ("sphinxcontrib_verilog_diagrams", "verilog_diagrams.rst"),
 ]
 import importlib
 for ext,docname in _optional_extensions:

--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -10,6 +10,7 @@ Verilog Domain test
    nesting2
 
    symbolator
+   verilog_diagrams
 
 ----
 

--- a/example/source/verilog/carry4-whole.v
+++ b/example/source/verilog/carry4-whole.v
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module CARRY4(output [3:0] CO, O, input CI, CYINIT, input [3:0] DI, S);
+  assign O = S ^ {CO[2:0], CI | CYINIT};
+  assign CO[0] = S[0] ? CI | CYINIT : DI[0];
+  assign CO[1] = S[1] ? CO[0] : DI[1];
+  assign CO[2] = S[2] ? CO[1] : DI[2];
+  assign CO[3] = S[3] ? CO[2] : DI[3];
+endmodule

--- a/example/source/verilog_diagrams.rst
+++ b/example/source/verilog_diagrams.rst
@@ -1,0 +1,19 @@
+Verilog Diagrams compatibility test
+***********************************
+
+.. TODO: use original version (commented below) when ansi-style module declarations become supported
+.. .. verilog:module:: module CARRY4(output [3:0] CO, O, input CI, CYINIT, input [3:0] DI, S);
+
+.. verilog:module:: module CARRY4(CO, O, CI, CYINIT, DI, S);
+
+    Source code without license:
+
+    .. no-license:: verilog/carry4-whole.v
+        :language: verilog
+        :linenos:
+
+    Diagram:
+
+    .. verilog-diagram:: verilog/carry4-whole.v
+        :type: netlistsvg
+        :module: CARRY4


### PR DESCRIPTION
Resolves #3

Preview: https://antmicro.github.io/sphinx-verilog-domain/verilog_diagrams.html

Reason for marking it as draft: depends on pending bugfix PR in sphinxcontrib-verilog-diagrams: https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams/pull/51.