### PR TITLE
Add namespace{,-push,-pop} directives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,3 +63,29 @@ Nesting::
                 Description of port ``a`` in ``Nested``
 
             Reference to module ``Top1``'s port ``a``: :verilog:ref:`Top1.a`.
+
+
+Namespaces
+^^^^^^^^^^
+
+There are three directives for changing current Verilog scope:
+
+* ``.. verilog:namespace:: A::B`` - sets current scope to ``A::B``. Using ``$root`` as an argument or using the directive without argument at all sets global namespace.
+
+* ``.. verilog:namespace-push:: C::D`` - sets current scope to ``C::D`` relatively to current scope
+
+* ``.. verilog:namespace-pop::`` - restores scope which was active before previous ``namespace-push`` was called. If there is no matching ``namespace-push``, scope is set to global scope.
+
+.. note::
+    ``verilog::namespace`` resets push/pop stack
+
+Example::
+
+    .. verilog:namespace:: A::B
+    .. verilog:port:: input inside_a_b;
+    .. verilog:namespace-push:: C::D
+    .. verilog:port:: input inside_a_b_c_d;
+    .. verilog:namespace-pop::
+    .. verilog:port:: input inside_a_b_again;
+    .. verilog:namespace::
+    .. verilog:port:: input in_global_namespace;

--- a/example/source/index.rst
+++ b/example/source/index.rst
@@ -8,6 +8,7 @@ Verilog Domain test
    module
    nesting
    nesting2
+   namespace
 
    symbolator
 

--- a/example/source/namespace.rst
+++ b/example/source/namespace.rst
@@ -1,0 +1,149 @@
+verilog:namespace{,-push,-pop}
+******************************
+
+* :verilog:ref:`$root::in_global_ns`
+* :verilog:ref:`$root::A::B::inside_a_b`
+* :verilog:ref:`$root::A::B::C::D::inside_a_b_c_d`
+* :verilog:ref:`$root::A::B::inside_a_b_again`
+* :verilog:ref:`$root::A::B::refname_inside_a_b`
+* :verilog:ref:`$root::A::B::X::Y::inside_a_b_x_y`
+* :verilog:ref:`$root::A::namespaces_test_module_in_a`
+* :verilog:ref:`$root::B::C::D::module_inside_b_c_d`
+* :verilog:ref:`$root::A::input_in_a`
+* :verilog:ref:`$root::global_ns_again`
+
+.. verilog:port:: input in_global_ns;
+
+::
+
+    .. verilog:namespace:: A::B
+
+.. verilog:namespace:: A::B
+
+.. verilog:port:: input inside_a_b;
+
+::
+
+    .. verilog:namespace-push:: C::D
+
+.. verilog:namespace-push:: C::D
+
+.. verilog:port:: input inside_a_b_c_d;
+
+::
+
+    .. verilog:namespace-pop::
+
+.. verilog:namespace-pop::
+
+.. verilog:port:: input inside_a_b_again;
+
+.. verilog:port:: input inside_a_b_with_refname;
+    :refname: refname_inside_a_b
+
+::
+
+    .. verilog:namespace-push:: X::Y
+
+.. verilog:namespace-push:: X::Y
+
+.. verilog:port:: input inside_a_b_x_y;
+
+::
+
+    .. verilog:namespace:: A
+
+.. verilog:namespace:: A
+
+.. verilog:module:: module namespaces_test_module_in_a(a);
+
+    ::
+
+        .. verilog:namespace:: B::C
+        .. verilog:namespace-push:: D
+
+    .. verilog:namespace:: B::C
+    .. verilog:namespace-push:: D
+
+    .. verilog:module:: module module_inside_b_c_d(a);
+
+Namespace changes applied inside a directive's content (e.g. in module description above) should not be propagated to a parent rst scope.
+
+.. verilog:port:: input input_in_a;
+
+::
+
+    .. verilog:namespace::
+
+.. verilog:namespace::
+
+.. verilog:port:: input global_ns_again;
+
+
+
+.. Empty lines to enable scrolling
+
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|
+|

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -289,7 +289,7 @@ class BaseVerilogDirective(ObjectDescription):
                 if obj.parent.linktarget:
                     parent_linktarget = obj.parent.linktarget
                 else:
-                    parent_linktarget = make_unique_linktarget(obj.name.normalize(), obj.parent, used_ids)
+                    parent_linktarget = make_unique_linktarget(obj.parent.name.normalize(), obj.parent, used_ids)
             else:
                 assert obj.name == VerilogIdentifier.ROOT_NAME, "Object must be added to domain's object tree before calling this function."
                 return "verilog"

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -218,7 +218,6 @@ class BaseVerilogDirective(ObjectDescription):
             new_values[0::2] = values
             return new_values
 
-
         names = []
         placeholders = []
         for n,p in self.names:
@@ -235,10 +234,10 @@ class BaseVerilogDirective(ObjectDescription):
                 decls += nodes.Text(" as ")
                 decls += nodes.literal(text=self.refname)
 
-            namespace = self.parent_object.qualified_name
+            namespace = VerilogQualifiedIdentifier(self.parent_object.qualified_name[1:])
             if len(namespace) > 0:
                 decls += nodes.Text(" in ")
-                decls += nodes.literal(text=".".join(namespace))
+                decls += nodes.literal(text=str(namespace))
         if placeholders:
             refs = nodes.line(text="Placeholders: ")
             dbg_info += refs

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -500,7 +500,7 @@ class VerilogDomainObject:
         return list(reversed(objects))
 
     def is_placeholder(self):
-        return self.parent is not None and self.parent.linktarget == self.linktarget
+        return self.parent is not None and self.linktarget and self.linktarget == self.parent.linktarget
 
     def is_only_namespace(self):
         return self.linktarget is None

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -180,7 +180,7 @@ class BaseVerilogDirective(ObjectDescription):
     @property
     def current_object(self):
         domain = self.env.get_domain("verilog")
-        return self.env.temp_data.setdefault("verilog:current_object", domain.objects)
+        return self.env.temp_data.setdefault("verilog:current_object", domain.root_object)
 
     @current_object.setter
     def current_object(self, value):
@@ -594,7 +594,7 @@ class VerilogDomain(Domain):
     }
 
     @property
-    def objects(self):
+    def root_object(self):
         return self.data["objects"]
 
     def _debug_enabled(self, cat):
@@ -606,14 +606,14 @@ class VerilogDomain(Domain):
             for child in obj.values():
                 yield from iter_tree(child)
 
-        for obj in iter_tree(self.objects):
+        for obj in iter_tree(self.root_object):
             if not (obj.is_only_namespace() or obj.is_placeholder()):
                 yield str(obj.qualified_name), str(obj.qualified_name), obj.objtype or "", obj.docname, obj.linktarget, 1
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         if self._debug_enabled("print_objects_tree") and not hasattr(self, "_dbg_resolve_xref_executed"):
             self._dbg_resolve_xref_executed = True
-            debug("objects_tree", self.objects.visualize_tree())
+            debug("objects_tree", self.root_object.visualize_tree())
 
         try:
             target_identifier = VerilogQualifiedIdentifier.fromstring(target)
@@ -639,9 +639,9 @@ class VerilogDomain(Domain):
         # Find leading identifier's object
         leading_identifier = target_identifier[0]
         if leading_identifier == VerilogIdentifier.ROOT_NAME:
-            obj = self.objects
+            obj = self.root_object
         else:
-            obj = node.attributes.get("verilog:parent_object") or self.objects
+            obj = node.attributes.get("verilog:parent_object") or self.root_object
             while obj and leading_identifier not in obj:
                 obj = obj.parent
             if not obj:

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -541,6 +541,9 @@ class VerilogDomainObject:
     def __setitem__(self, key, obj):
         assert isinstance(obj, VerilogDomainObject)
         assert obj not in self.path()
+        key = VerilogIdentifier(key)
+        if key == VerilogIdentifier.ROOT_NAME:
+            raise ValueError(f"Invalid identifier: {key}")
 
         if key in self:
             del self[key]


### PR DESCRIPTION
Adds 3 directives:

* `.. verilog:namespace:: A::B` - sets current scope to `A::B`. Using `$root` as an argument or using the directive without argument at all sets global namespace.
* `.. verilog:namespace-push:: C::D` - sets current scope to `C::D` relatively to current scope
* `.. verilog:namespace-pop::` - restores scope which was active before previous `namespace-push` was called. If there is no matching `namespace-push`, scope is set to global scope.

Directives functionality is analogous to their counterparts in other domains e.g. https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#namespacing

Preview:
https://antmicro.github.io/sphinx-verilog-domain/namespace.html