### PR TITLE
Add support for parameters in module declaration header

### DIFF
--- a/example/source/module.rst
+++ b/example/source/module.rst
@@ -10,3 +10,59 @@ verilog:module
 .. verilog:module:: module same_input (a,a);
 .. verilog:module:: module mixed_direction (.p({a, e}));
 
+Module parameters
+=================
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_1 #() (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_1`
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_2 #(num = 3, other_num = 2 * 2) (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_2`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_3 #(num, other_num) (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_3`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+
+    Parameter :verilog:ref:`other_num` is explicitly described below. The declaration in module header should link to it.
+
+    .. verilog:parameter:: parameter other_num = 2 * 2;
+
+        Parameter description.
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_4 # (parameter num = 3, other_num = 2 * 2) (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_4`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_5 # (parameter num = 3, localparam other_num = 2 * 2, yet_another_one = 42) (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_5`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+    :verilog:ref:`yet_another_one`
+
+    Parameter :verilog:ref:`num` is explicitly described below. The declaration in module header should link to it.
+
+    .. verilog:parameter:: parameter num;
+
+        Parameter description.
+
+.. verilog:module:: (* x=1 *) module non_ansi_params_test_6 # (parameter num = 3, localparam other_num, yet_another_one = 42) (port_name);
+
+    References:
+    :verilog:ref:`non_ansi_params_test_6`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+    :verilog:ref:`yet_another_one`

--- a/sphinxcontrib/verilog.lark
+++ b/sphinxcontrib/verilog.lark
@@ -262,6 +262,7 @@ _ESCAPED_IDENTIFIER: "\\" /[\x21-\x7E]+/ " "
 
 SYM_SEMICOLON: ";"
 SYM_COMMA: ","
+SYM_HASH: "#"
 
 OP_DOT: "."
 OP_EQUAL: "="
@@ -310,8 +311,10 @@ module: non_ansi_module_decl SYM_SEMICOLON?
 
 id_module.-1: ID
 id_ext_port.-1: ID
+parameter_decl_or_assignment: KW_PARAM? KW_OTHER* expr_bracket* parameter_assignment
+parameter_port_list: SYM_HASH SYM_PAREN_L (parameter_decl_or_assignment (SYM_COMMA parameter_decl_or_assignment)*)? SYM_PAREN_R
 port_expr: port_ref
          | SYM_BRACE_L port_ref (SYM_COMMA port_ref)* SYM_BRACE_R
 non_ansi_module_port: port_expr
                     | OP_DOT id_ext_port SYM_PAREN_L port_expr? SYM_PAREN_R
-non_ansi_module_decl: (expr_attr)? KW_MODULE id_module SYM_PAREN_L non_ansi_module_port (SYM_COMMA non_ansi_module_port)* SYM_PAREN_R
+non_ansi_module_decl: (expr_attr)? KW_MODULE id_module parameter_port_list? SYM_PAREN_L non_ansi_module_port (SYM_COMMA non_ansi_module_port)* SYM_PAREN_R

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -366,7 +366,7 @@ class ModuleDirective(BaseVerilogDirective):
     start_rule = "module"
 
     def process_token(self, token, rules=[]):
-        if token.type == "ID" and "id_port" in rules:
+        if token.type == "ID" and {"id_port", "id_parameter"}.intersection(rules):
             name = VerilogIdentifier(token.value)
             yield ("placeholder", name)
 


### PR DESCRIPTION
Support for syntax like:
```
module non_ansi_params_test #(param_1 = 2, param_2 = 3) (port_name);
```

Preview: https://antmicro.github.io/sphinx-verilog-domain/module.html#module-parameters