### PR TITLE
Add support for ANSI-style module declarations

### DIFF
--- a/example/source/module.rst
+++ b/example/source/module.rst
@@ -1,6 +1,167 @@
 verilog:module
 **************
 
+.. verilog:module:: module module_test();
+
+ANSI style
+==========
+
+.. verilog:module:: module ansi_top (input wire i_clk, input wire i_inp, output reg o_out);
+
+    References:
+    :verilog:ref:`ansi_top`
+    :verilog:ref:`i_clk`
+    :verilog:ref:`i_inp`
+    :verilog:ref:`o_out`
+
+.. verilog:module:: module ansi_style_1(input x);
+
+    References:
+    :verilog:ref:`ansi_style_1`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_2(input x, output y);
+
+    References:
+    :verilog:ref:`ansi_style_2`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_3(wire x);
+
+    References:
+    :verilog:ref:`ansi_style_3`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_4(output signed x);
+
+    References:
+    :verilog:ref:`ansi_style_4`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_5(output signed x = 1);
+
+    References:
+    :verilog:ref:`ansi_style_5`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_6(input x = 0, output y = 2*2);
+
+    References:
+    :verilog:ref:`ansi_style_6`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_7(inout integer x);
+
+    References:
+    :verilog:ref:`ansi_style_7`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_8(output [7:0] x);
+
+    References:
+    :verilog:ref:`ansi_style_8`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_9(input signed [7:0] x);
+
+    References:
+    :verilog:ref:`ansi_style_9`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_10([7:0] x);
+
+    References:
+    :verilog:ref:`ansi_style_10`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_11([7:0] x, input y);
+
+    References:
+    :verilog:ref:`ansi_style_11`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_12((* attr *) output integer x);
+
+    References:
+    :verilog:ref:`ansi_style_12`
+    :verilog:ref:`x`
+
+.. verilog:module:: module ansi_style_13((* attr *) output integer x, (* attr_other *) input [3:0] y);
+
+    References:
+    :verilog:ref:`ansi_style_13`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_14((* attr *) output integer [7:0] x, (* other, attr *) wire y);
+
+    References:
+    :verilog:ref:`ansi_style_14`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_15(ref [7:0] x, y);
+
+    References:
+    :verilog:ref:`ansi_style_15`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_16(ref x [7:0], y);
+
+    References:
+    :verilog:ref:`ansi_style_16`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+.. verilog:module:: module ansi_style_17(ref [7:0] x [7:0], y);
+
+    References:
+    :verilog:ref:`ansi_style_17`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+
+
+.. verilog:module:: module ansi_style_18 (
+                        input .ext1(x[7:4]),
+                        input .ext2(x[3:0]),
+                        inout y,
+                        output .ext3(z)
+                    );
+
+    References:
+    :verilog:ref:`ansi_style_18`
+    :verilog:ref:`x`
+    :verilog:ref:`y`
+    :verilog:ref:`z`
+
+
+.. verilog:module:: module ansi_style_19 (
+                        input [7:0] a,
+                        input signed [7:0] b, c, d,
+                        output [7:0] e,
+                        output var signed [7:0] f, g,
+                        output signed [7:0] h
+                    );
+
+    References:
+    :verilog:ref:`ansi_style_19`
+    :verilog:ref:`a`
+    :verilog:ref:`b`
+    :verilog:ref:`c`
+    :verilog:ref:`d`
+    :verilog:ref:`e`
+    :verilog:ref:`f`
+    :verilog:ref:`g`
+    :verilog:ref:`h`
+
+
+Non-ANSI style
+==============
+
 .. verilog:module:: (* attr = 2 * 2 *) module test1(a,b,c,d,e,f,g,h);
 .. verilog:module:: module test2(a,b,c,d,e,f,g,h);
 .. verilog:module:: module complex_ports ( {c,d}, .e(f) );
@@ -18,6 +179,11 @@ Module parameters
     References:
     :verilog:ref:`non_ansi_params_test_1`
 
+.. verilog:module:: (* x=1 *) module ansi_params_test_1 #() (input port_name);
+
+    References:
+    :verilog:ref:`ansi_params_test_1`
+
 .. verilog:module:: (* x=1 *) module non_ansi_params_test_2 #(num = 3, other_num = 2 * 2) (port_name);
 
     References:
@@ -25,10 +191,30 @@ Module parameters
     :verilog:ref:`num`,
     :verilog:ref:`other_num`
 
+.. verilog:module:: (* x=1 *) module ansi_params_test_2 #(num = 3, other_num = 2 * 2) (input port_name);
+
+    References:
+    :verilog:ref:`ansi_params_test_2`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+
 .. verilog:module:: (* x=1 *) module non_ansi_params_test_3 #(num, other_num) (port_name);
 
     References:
     :verilog:ref:`non_ansi_params_test_3`,
+    :verilog:ref:`num`,
+    :verilog:ref:`other_num`
+
+    Parameter :verilog:ref:`other_num` is explicitly described below. The declaration in module header should link to it.
+
+    .. verilog:parameter:: parameter other_num = 2 * 2;
+
+        Parameter description.
+
+.. verilog:module:: (* x=1 *) module ansi_params_test_3 #(num, other_num) (input port_name);
+
+    References:
+    :verilog:ref:`ansi_params_test_3`,
     :verilog:ref:`num`,
     :verilog:ref:`other_num`
 

--- a/sphinxcontrib/verilog.lark
+++ b/sphinxcontrib/verilog.lark
@@ -307,14 +307,17 @@ parameter_decl: KW_PARAM KW_OTHER* expr_bracket* parameter_assignment (SYM_COMMA
 
 // Modules
 
-module: non_ansi_module_decl SYM_SEMICOLON?
+module: module_decl SYM_SEMICOLON?
 
 id_module.-1: ID
 id_ext_port.-1: ID
 parameter_decl_or_assignment: KW_PARAM? KW_OTHER* expr_bracket* parameter_assignment
 parameter_port_list: SYM_HASH SYM_PAREN_L (parameter_decl_or_assignment (SYM_COMMA parameter_decl_or_assignment)*)? SYM_PAREN_R
-port_expr: port_ref
-         | SYM_BRACE_L port_ref (SYM_COMMA port_ref)* SYM_BRACE_R
-non_ansi_module_port: port_expr
-                    | OP_DOT id_ext_port SYM_PAREN_L port_expr? SYM_PAREN_R
-non_ansi_module_decl: (expr_attr)? KW_MODULE id_module parameter_port_list? SYM_PAREN_L non_ansi_module_port (SYM_COMMA non_ansi_module_port)* SYM_PAREN_R
+
+module_port_expr: port_ref
+                | SYM_BRACE_L port_ref (SYM_COMMA port_ref)* SYM_BRACE_R
+module_port: KW_OTHER* expr_bracket* module_port_expr
+           | KW_OTHER? OP_DOT id_ext_port SYM_PAREN_L (module_port_expr)? SYM_PAREN_R
+module_port_assignment: module_port (OP_EQUAL expr+)?
+module_port_list: (expr_attr)? module_port_assignment (SYM_COMMA (expr_attr)? module_port_assignment)*
+module_decl: (expr_attr)? KW_MODULE id_module parameter_port_list? SYM_PAREN_L module_port_list? SYM_PAREN_R

--- a/sphinxcontrib/verilogdomain.py
+++ b/sphinxcontrib/verilogdomain.py
@@ -130,6 +130,7 @@ class BaseVerilogDirective(ObjectDescription):
         return (
                 (p[0] in ["KW", "ID", "TEXT"] and c[0] in ["KW", "ID", "TEXT"]) or
                 (p[0] in ["KW"] and c[-1] in ["L"]) or
+                (p[0] in ["KW"] and c[0] in ["OP"]) or
                 ((p == "SYM_ATTR_PAREN_L".split("_")) or (c == "SYM_ATTR_PAREN_R".split("_"))) or
                 (p[0] in ["SYM"] and p[-1] not in ["L"] and c[0] in ["KW", "ID", "TEXT", "OP"]) or
                 (p == "OP_EQUAL".split("_") or c == "OP_EQUAL".split("_"))


### PR DESCRIPTION
Depends on: https://github.com/SymbiFlow/sphinx-verilog-domain/pull/11
Closes: #5

Preview: https://antmicro.github.io/sphinx-verilog-domain/module.html#ansi-style

The only reason for marking this as a WIP is the dependency on unmerged PR.