### PR TITLE
travis: Manual cleanup before deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
       name: "PyPI"
       before_deploy:
         - sudo ln -sf /usr/bin/python3 /usr/bin/python
+        - rm -rf env
       deploy:
         provider: pypi
         username: __token__


### PR DESCRIPTION
```
Cleaning up git repository with `git stash --all`. If you need build artifacts for deployment, set `deploy.skip_cleanup: true`. See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup.
warning: CRLF will be replaced by LF in env/conda/envs/sphinx-verilog-domain/lib/node_modules/netlistsvg/node_modules/@types/clone/README.md.
2361The file will have its original line endings in your working directory
2362warning: CRLF will be replaced by LF in env/conda/envs/sphinx-verilog-domain/lib/node_modules/netlistsvg/node_modules/@types/clone/index.d.ts.
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>