### PR TITLE
travis: Move `make env` into the `install:` step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ git:
 
 before_install:
   - git fetch --tags
+
+install:
   - make env
   - source env/conda/bin/activate sphinx-verilog-domain
 
@@ -21,7 +23,7 @@ jobs:
 
     - stage: Deploy
       name: "PyPI"
-      before_install: null
+      install: null
       before_deploy:
         - sudo ln -sf /usr/bin/python3 /usr/bin/python
       deploy:


### PR DESCRIPTION
`before_install` runs the git commands (and thus should run on deploy as
well as build).

`install` sets up the conda environment, installs local packages, etc.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>